### PR TITLE
georep: Add roles for glusterfs_volume geo-replication.

### DIFF
--- a/roles/geo-replication/georep-create/README.md
+++ b/roles/geo-replication/georep-create/README.md
@@ -1,0 +1,59 @@
+georep-create
+=============
+
+Creates a Geo-replication session.
+
+Requirements
+------------
+
+Ansible 2.3 and above
+GlusterFS 3.x and above
+
+Role Variables
+--------------
+
+| parameters | required | default | choices | comments |
+| --- | --- | --- | --- | --- |
+| state | yes | | **georep-create** / **georep-delete** / **georep-start** / **georep-stop** / **georep-resume**/ **georep-config** | Based on the state, the geo-replication sessions are created, deleted, started, stopped, paused, resumed, or configured. |
+| force | no | | **yes** / **no** | Force option will be used while creating a georep session, any warnings will be suppressed. |
+| gluster_hosts | yes | |  | Contains the list of hosts required to set a georep session. |
+| mastervol | yes | |  | Name of the master volume. Refer GlusterFS documentation for valid characters in a volume name. |
+| slavevol | yes | |  | Name of the slave volume. Refer GlusterFS documentation for valid characters in a volume name. |
+
+Dependencies
+------------
+
+None.
+
+Example Playbook
+----------------
+
+Create a Geo-replication session
+
+```
+
+---
+
+- hosts: georep_master
+  remote_user: root
+  gather_facts: no
+
+  tasks:
+  - include_role:
+      name: geo-replication/georep-create
+    vars:
+        state: georep-create
+        gluster_hosts:
+          - 10.70.43.142
+          - 10.70.42.25
+        mastervol: mastervol
+        slavevol: slavevol
+        force: true
+
+```
+
+License
+-------
+
+GPLv3
+

--- a/roles/geo-replication/georep-create/defaults/main.yml
+++ b/roles/geo-replication/georep-create/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+# defaults file for georep-create
+state: georep-create
+mastervol: mastervol
+slavevol: slavevol
+force: true
+secure: no

--- a/roles/geo-replication/georep-create/handlers/main.yml
+++ b/roles/geo-replication/georep-create/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for georep-create

--- a/roles/geo-replication/georep-create/meta/main.yml
+++ b/roles/geo-replication/georep-create/meta/main.yml
@@ -1,0 +1,3 @@
+galaxy_info:
+  author: Devyani Kota
+  min_ansible_version: 1.2

--- a/roles/geo-replication/georep-create/tasks/main.yml
+++ b/roles/geo-replication/georep-create/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+# tasks file for georep-create
+
+- name: Create a geo-replication session
+  glusterfs_volume:
+           state=georep-create
+           mastervol="{{ mastervol }}"
+           slavevol="{{ slavevol }}"
+           hosts="{{ gluster_hosts }}"
+           force="{{ force | default('no') }}"
+           secure="{{ secure | default('no') }}"

--- a/roles/geo-replication/georep-create/tests/inventory
+++ b/roles/geo-replication/georep-create/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/geo-replication/georep-create/tests/test.yml
+++ b/roles/geo-replication/georep-create/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - georep-create

--- a/roles/geo-replication/georep-create/tests/vars.yml
+++ b/roles/geo-replication/georep-create/tests/vars.yml
@@ -1,0 +1,11 @@
+---
+# Example vars file for georep-create
+
+gluster_hosts:
+  - 10.70.43.142
+  - 10.70.42.25
+state: georep-create
+mastervol: 10.70.43.142:mastervol
+slavevol: 10.70.42.25:slavevol
+force: true
+secure: no

--- a/roles/geo-replication/georep-create/vars/main.yml
+++ b/roles/geo-replication/georep-create/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for georep-create

--- a/roles/geo-replication/georep-delete/README.md
+++ b/roles/geo-replication/georep-delete/README.md
@@ -1,0 +1,56 @@
+georep-delete
+=============
+
+Deletes a Geo-replication session.
+
+Requirements
+------------
+
+Ansible 2.3 and above
+GlusterFS 3.x and above
+
+Role Variables
+--------------
+
+| parameters | required | default | choices | comments |
+| --- | --- | --- | --- | --- |
+| state | yes | | **georep-create** / **georep-delete** / **georep-start** / **georep-stop** / **georep-resume**/ **georep-config** | Based on the state, the geo-replication sessions are created, deleted, started, stopped, paused, resumed, or configured. |
+| mastervol | yes | |  | Name of the master volume. Refer GlusterFS documentation for valid characters in a volume name. |
+| slavevol | yes | |  | Name of the slave volume. Refer GlusterFS documentation for valid characters in a volume name. |
+
+Dependencies
+------------
+
+None.
+
+Example Playbook
+----------------
+
+Delete a Geo-replication session
+
+```
+
+---
+
+- hosts: georep_master
+  remote_user: root
+  gather_facts: no
+
+  tasks:
+  - include_role:
+      name: geo-replication/georep-delete
+    vars:
+        state: georep-delete
+        gluster_hosts:
+          - 10.70.43.142
+          - 10.70.42.25
+        mastervol: mastervol
+        slavevol: slavevol
+
+```
+
+License
+-------
+
+GPLv3
+

--- a/roles/geo-replication/georep-delete/defaults/main.yml
+++ b/roles/geo-replication/georep-delete/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+# defaults file for georep-delete
+state: georep-delete
+mastervol: mastervol
+slavevol: slavevol
+force: true
+secure: no

--- a/roles/geo-replication/georep-delete/handlers/main.yml
+++ b/roles/geo-replication/georep-delete/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for georep-delete

--- a/roles/geo-replication/georep-delete/meta/main.yml
+++ b/roles/geo-replication/georep-delete/meta/main.yml
@@ -1,0 +1,3 @@
+galaxy_info:
+  author: Devyani Kota
+  min_ansible_version: 1.2

--- a/roles/geo-replication/georep-delete/tasks/main.yml
+++ b/roles/geo-replication/georep-delete/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+# tasks file for georep-delete
+
+- name: Delete a geo-replication session
+  glusterfs_volume:
+           state=georep-delete
+           mastervol="{{ mastervol }}"
+           slavevol="{{ slavevol }}"
+           hosts="{{ gluster_hosts }}"

--- a/roles/geo-replication/georep-delete/tests/inventory
+++ b/roles/geo-replication/georep-delete/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/geo-replication/georep-delete/tests/test.yml
+++ b/roles/geo-replication/georep-delete/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - georep-delete

--- a/roles/geo-replication/georep-delete/tests/vars.yml
+++ b/roles/geo-replication/georep-delete/tests/vars.yml
@@ -1,0 +1,9 @@
+---
+# Example vars file for georep-delete
+
+gluster_hosts:
+  - 10.70.43.142
+  - 10.70.42.25
+state: georep-delete
+mastervol: 10.70.43.142:mastervol
+slavevol: 10.70.42.25:slavevol

--- a/roles/geo-replication/georep-delete/vars/main.yml
+++ b/roles/geo-replication/georep-delete/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for georep-delete


### PR DESCRIPTION
A user can set up a geo-replication session using the
gdeploy/glusterfs_volume module by providing the value
of state as georep-create.

Signed-off-by: Devyani Kota <devyanikota@gmail.com>