### PR TITLE
Using shell module instead gluster_peer for gluster peer detach

### DIFF
--- a/playbooks/hc-ansible-deployment/tasks/gluster_cleanup.yml
+++ b/playbooks/hc-ansible-deployment/tasks/gluster_cleanup.yml
@@ -74,9 +74,8 @@
         state: absent
 
     - name: Delete a node from the trusted storage pool
-      gluster_peer:
-        state: absent
-        nodes: "{{ cluster_nodes }}"
+      shell: gluster peer detach {{ item }} --mode=script
+      with_items: "{{ cluster_nodes }}"
 
   tags:
     - cleanup_bricks

--- a/playbooks/hc-ansible-deployment/tasks/gluster_cleanup.yml
+++ b/playbooks/hc-ansible-deployment/tasks/gluster_cleanup.yml
@@ -73,9 +73,16 @@
         path: /usr/share/cockpit/ovirt-dashboard/ansible/ansibleStatus.conf
         state: absent
 
+    - name: Get the list of hosts to be detached
+      shell: gluster pool list | egrep -vw '(localhost|Hostname)' | awk '{print $2}'
+      register: peernodes
+      run_once: true
+
     - name: Delete a node from the trusted storage pool
-      shell: gluster peer detach {{ item }} --mode=script
+      command: gluster peer detach {{ item }} --mode=script
       with_items: "{{ cluster_nodes }}"
+      when: item != inventory_hostname and peernodes.stdout_lines|length > 0
+      run_once: true
 
   tags:
     - cleanup_bricks


### PR DESCRIPTION
Right now gluster_peer module does not support backward compatibility.So using shell module for now.