### PR TITLE
Fixed hostname validation check

### DIFF
--- a/playbooks/hc-ansible-deployment/tasks/gluster_deployment.yml
+++ b/playbooks/hc-ansible-deployment/tasks/gluster_deployment.yml
@@ -28,8 +28,8 @@
     - name: Check if provided hostnames are valid
       assert:
         that:
-          - "result.results[0]['rc'] == 0"
-          - "result.results[0]['stdout_lines'] > 0"
+          - "result['rc'] == 0"
+          - "result['stdout_lines'] | length > 0"
         fail_msg: "The given hostname is not valid FQDN"
       when: gluster_features_fqdn_check | default(true)
 


### PR DESCRIPTION
The condition was failing in python3 and ansible 2.8.5. Now condition is compatible with both python2 and 3 and respective ansible versions.