### PR TITLE
Fixing emulate512  setting it  to 'off'

### DIFF
--- a/playbooks/hc-ansible-deployment/gluster_inventory.yml
+++ b/playbooks/hc-ansible-deployment/gluster_inventory.yml
@@ -20,9 +20,9 @@ hc_nodes:
       # writepolicy       - auto
       #
       # gluster_infra_vdo:
-      #   - { name: 'vdo_sdc', device: '/dev/sdc', logicalsize: '5000G', emulate512: 'on', slabsize: '32G',
+      #   - { name: 'vdo_sdc', device: '/dev/sdc', logicalsize: '5000G', emulate512: 'off', slabsize: '32G',
       #       blockmapcachesize:  '128M', readcachesize: '20M', readcache: 'enabled', writepolicy: 'auto' }
-      #   - { name: 'vdo_sdd', device: '/dev/sdd', logicalsize: '3000G', emulate512: 'on', slabsize: '32G',
+      #   - { name: 'vdo_sdd', device: '/dev/sdd', logicalsize: '3000G', emulate512: 'off', slabsize: '32G',
       #       blockmapcachesize:  '128M', readcachesize: '20M', readcache: 'enabled', writepolicy: 'auto' }
 
       # When dedupe and compression is enabled on the device, 
@@ -115,9 +115,9 @@ hc_nodes:
       # writepolicy       - auto
       #
       # gluster_infra_vdo:
-      #   - { name: 'vdo_sdc', device: '/dev/sdc', logicalsize: '5000G', emulate512: 'on', slabsize: '32G',
+      #   - { name: 'vdo_sdc', device: '/dev/sdc', logicalsize: '5000G', emulate512: 'off', slabsize: '32G',
       #       blockmapcachesize:  '128M', readcachesize: '20M', readcache: 'enabled', writepolicy: 'auto' }
-      #   - { name: 'vdo_sdd', device: '/dev/sdd', logicalsize: '3000G', emulate512: 'on', slabsize: '32G',
+      #   - { name: 'vdo_sdd', device: '/dev/sdd', logicalsize: '3000G', emulate512: 'off', slabsize: '32G',
       #       blockmapcachesize:  '128M', readcachesize: '20M', readcache: 'enabled', writepolicy: 'auto' }
 
       # When dedupe and compression is enabled on the device, 
@@ -210,9 +210,9 @@ hc_nodes:
       # writepolicy       - auto
       #
       # gluster_infra_vdo:
-      #   - { name: 'vdo_sdc', device: '/dev/sdc', logicalsize: '5000G', emulate512: 'on', slabsize: '32G',
+      #   - { name: 'vdo_sdc', device: '/dev/sdc', logicalsize: '5000G', emulate512: 'off', slabsize: '32G',
       #       blockmapcachesize:  '128M', readcachesize: '20M', readcache: 'enabled', writepolicy: 'auto' }
-      #   - { name: 'vdo_sdd', device: '/dev/sdd', logicalsize: '3000G', emulate512: 'on', slabsize: '32G',
+      #   - { name: 'vdo_sdd', device: '/dev/sdd', logicalsize: '3000G', emulate512: 'off', slabsize: '32G',
       #       blockmapcachesize:  '128M', readcachesize: '20M', readcache: 'enabled', writepolicy: 'auto' }
  
       # When dedupe and compression is enabled on the device, 


### PR DESCRIPTION
Bug-ur: https://bugzilla.redhat.com/show_bug.cgi?id=1789316

This change edits the  inventory file used for deployment , which still contains emulate512=on, it has been set as off
Signed-off-by: Prajith Kesava Prasad <pkesavap@redhat.com>