### PR TITLE
Added he_vcpus variable in var file

### DIFF
--- a/playbooks/hc-ansible-deployment/he_gluster_vars.json
+++ b/playbooks/hc-ansible-deployment/he_gluster_vars.json
@@ -13,5 +13,6 @@
   "he_bridge_if": "interface name for bridge creation",
   "he_enable_hc_gluster_service": true,
   "he_mem_size_MB": "16384",
-  "he_cluster": "Default"
+  "he_cluster": "Default",
+  "he_vcpus": 4
 }


### PR DESCRIPTION
When RHHI-V deployment is completed with ansible playbooks using CLI, the deployment is successful, but migration of HE VM to other host is not possible. The HE vm is all the available core and because of this migration of HE vm to other node is not possible.

Bug-URL- https://bugzilla.redhat.com/show_bug.cgi?id=1901364