### PR TITLE
add a condition to be able to skip the add additional gluster hosts

### DIFF
--- a/playbooks/hc-ansible-deployment/tasks/add_hosts_storage_domains.yml
+++ b/playbooks/hc-ansible-deployment/tasks/add_hosts_storage_domains.yml
@@ -30,7 +30,9 @@
     with_items: "{{ groups['gluster'] }}"
     loop_control:
      loop_var: host
-    when: "'gluster' in groups"
+    when:
+      - "'gluster' in groups"
+      - add_additional_gluster_hosts | default(true)
 
   - name: "Add additional glusterfs storage domains"
     ignore_errors: true


### PR DESCRIPTION
add flag add_additional_gluster_hosts with default: true for backward compatibility 
but with this flag, we have the option to skip adding additional gluster hosts in this playbook. 